### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -7,7 +7,7 @@ import type { ArbitrageOpportunity } from '../types';
 function escapeMarkdownV2(text: string | number): string {
   const textStr = String(text);
   // Characters to escape: _ * [ ] ( ) ~ ` > # + - = | { } . !
-  const charsToEscape = /[_*\[\]()~`>#+\-=|{}.!]/g;
+  const charsToEscape = /[_*\[\]()~`>#+\-=|{}.!\\]/g;
   return textStr.replace(charsToEscape, '\\$&');
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/irfndi/ArbEdge/security/code-scanning/4](https://github.com/irfndi/ArbEdge/security/code-scanning/4)

To fix the issue, we need to ensure that backslashes are escaped in addition to the other MarkdownV2 special characters. This can be achieved by modifying the `charsToEscape` regex to include backslashes (`\`) and ensuring that the `replace` method correctly escapes them. The updated regex should be `/[_*\[\]()~`>#+\-=|{}.!\\]/g`, where the backslash is escaped as `\\` within the regex.

Additionally, the `replace` method will remain unchanged, as it already uses `\\$&` to prepend a backslash to each matched character, including the newly added backslash.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
