### PR TITLE
Check Cloudflare Workers runtime error

### DIFF
--- a/src/services/core/infrastructure/database_repositories/database_manager.rs
+++ b/src/services/core/infrastructure/database_repositories/database_manager.rs
@@ -430,7 +430,12 @@ impl DatabaseManager {
             })?
             .all()
             .await
-            .map_err(|e| ArbitrageError::database_error(format!("Failed to execute D1 query '{}': {}", query, e)));
+            .map_err(|e| {
+                ArbitrageError::database_error(format!(
+                    "Failed to execute D1 query '{}': {}",
+                    query, e
+                ))
+            });
 
         if let Err(e) = &result {
             console_log!("D1 query error: {:?}", e);
@@ -454,12 +459,18 @@ impl DatabaseManager {
         let result = stmt
             .bind(params)
             .map_err(|e| {
-                ArbitrageError::database_error(format!("Failed to bind parameters for statement '{}': {}", query, e))
+                ArbitrageError::database_error(format!(
+                    "Failed to bind parameters for statement '{}': {}",
+                    query, e
+                ))
             })?
             .run()
             .await
             .map_err(|e| {
-                ArbitrageError::database_error(format!("Failed to execute D1 statement '{}': {}", query, e))
+                ArbitrageError::database_error(format!(
+                    "Failed to execute D1 statement '{}': {}",
+                    query, e
+                ))
             });
 
         if let Err(e) = &result {

--- a/src/services/core/infrastructure/database_repositories/database_manager.rs
+++ b/src/services/core/infrastructure/database_repositories/database_manager.rs
@@ -420,22 +420,20 @@ impl DatabaseManager {
         let stmt = self.db.prepare(query);
 
         console_log!("Executing D1 query: {}", query);
-        let result = stmt
-            .bind(params)
-            .map_err(|e| ArbitrageError::database_error(format!("Failed to bind parameters for query '{}': {}", query, e)));
+        let result = stmt.bind(params).map_err(|e| {
+            ArbitrageError::database_error(format!(
+                "Failed to bind parameters for query '{}': {}",
+                query, e
+            ))
+        });
 
         let result = match result {
-            Ok(bound_stmt) => {
-                bound_stmt
-                    .all()
-                    .await
-                    .map_err(|e| {
-                        ArbitrageError::database_error(format!(
-                            "Failed to execute D1 query '{}': {}",
-                            query, e
-                        ))
-                    })
-            },
+            Ok(bound_stmt) => bound_stmt.all().await.map_err(|e| {
+                ArbitrageError::database_error(format!(
+                    "Failed to execute D1 query '{}': {}",
+                    query, e
+                ))
+            }),
             Err(e) => Err(e),
         };
 
@@ -458,22 +456,20 @@ impl DatabaseManager {
         let start_time = current_timestamp_ms();
 
         let stmt = self.db.prepare(query);
-        let result = stmt
-            .bind(params)
-            .map_err(|e| ArbitrageError::database_error(format!("Failed to bind parameters for statement '{}': {}", query, e)));
+        let result = stmt.bind(params).map_err(|e| {
+            ArbitrageError::database_error(format!(
+                "Failed to bind parameters for statement '{}': {}",
+                query, e
+            ))
+        });
 
         let result = match result {
-            Ok(bound_stmt) => {
-                bound_stmt
-                    .run()
-                    .await
-                    .map_err(|e| {
-                        ArbitrageError::database_error(format!(
-                            "Failed to execute D1 statement '{}': {}",
-                            query, e
-                        ))
-                    })
-            },
+            Ok(bound_stmt) => bound_stmt.run().await.map_err(|e| {
+                ArbitrageError::database_error(format!(
+                    "Failed to execute D1 statement '{}': {}",
+                    query, e
+                ))
+            }),
             Err(e) => Err(e),
         };
 

--- a/src/services/core/infrastructure/database_repositories/database_manager.rs
+++ b/src/services/core/infrastructure/database_repositories/database_manager.rs
@@ -422,20 +422,22 @@ impl DatabaseManager {
         console_log!("Executing D1 query: {}", query);
         let result = stmt
             .bind(params)
-            .map_err(|e| {
-                ArbitrageError::database_error(format!(
-                    "Failed to bind parameters for query '{}': {}",
-                    query, e
-                ))
-            })?
-            .all()
-            .await
-            .map_err(|e| {
-                ArbitrageError::database_error(format!(
-                    "Failed to execute D1 query '{}': {}",
-                    query, e
-                ))
-            });
+            .map_err(|e| ArbitrageError::database_error(format!("Failed to bind parameters for query '{}': {}", query, e)));
+
+        let result = match result {
+            Ok(bound_stmt) => {
+                bound_stmt
+                    .all()
+                    .await
+                    .map_err(|e| {
+                        ArbitrageError::database_error(format!(
+                            "Failed to execute D1 query '{}': {}",
+                            query, e
+                        ))
+                    })
+            },
+            Err(e) => Err(e),
+        };
 
         if let Err(e) = &result {
             console_log!("D1 query error: {:?}", e);
@@ -458,20 +460,22 @@ impl DatabaseManager {
         let stmt = self.db.prepare(query);
         let result = stmt
             .bind(params)
-            .map_err(|e| {
-                ArbitrageError::database_error(format!(
-                    "Failed to bind parameters for statement '{}': {}",
-                    query, e
-                ))
-            })?
-            .run()
-            .await
-            .map_err(|e| {
-                ArbitrageError::database_error(format!(
-                    "Failed to execute D1 statement '{}': {}",
-                    query, e
-                ))
-            });
+            .map_err(|e| ArbitrageError::database_error(format!("Failed to bind parameters for statement '{}': {}", query, e)));
+
+        let result = match result {
+            Ok(bound_stmt) => {
+                bound_stmt
+                    .run()
+                    .await
+                    .map_err(|e| {
+                        ArbitrageError::database_error(format!(
+                            "Failed to execute D1 statement '{}': {}",
+                            query, e
+                        ))
+                    })
+            },
+            Err(e) => Err(e),
+        };
 
         if let Err(e) = &result {
             console_log!("D1 statement error: {:?}", e);

--- a/src/services/core/infrastructure/database_repositories/database_manager.rs
+++ b/src/services/core/infrastructure/database_repositories/database_manager.rs
@@ -10,7 +10,7 @@ use crate::utils::{ArbitrageError, ArbitrageResult};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use worker::{kv::KvStore, wasm_bindgen::JsValue, D1Database, console_log};
+use worker::{console_log, kv::KvStore, wasm_bindgen::JsValue, D1Database};
 
 // For D1Result JsValue conversion
 use worker::js_sys;
@@ -418,16 +418,24 @@ impl DatabaseManager {
         let start_time = current_timestamp_ms();
 
         let stmt = self.db.prepare(query);
-        
+
         console_log!("Executing D1 query: {}", query);
         let result = stmt
             .bind(params)
             .map_err(|e| {
-                ArbitrageError::database_error(format!("Failed to bind parameters for query '{}': {}", query, e))
+                ArbitrageError::database_error(format!(
+                    "Failed to bind parameters for query '{}': {}",
+                    query, e
+                ))
             })?
             .all()
             .await
-            .map_err(|e| ArbitrageError::database_error(format!("Failed to execute D1 query '{}': {}", query, e)));
+            .map_err(|e| {
+                ArbitrageError::database_error(format!(
+                    "Failed to execute D1 query '{}': {}",
+                    query, e
+                ))
+            });
 
         if result.is_err() {
             console_log!("D1 query error: {}", result.as_ref().unwrap_err());
@@ -452,12 +460,18 @@ impl DatabaseManager {
         let result = stmt
             .bind(params)
             .map_err(|e| {
-                ArbitrageError::database_error(format!("Failed to bind parameters for statement '{}': {}", query, e))
+                ArbitrageError::database_error(format!(
+                    "Failed to bind parameters for statement '{}': {}",
+                    query, e
+                ))
             })?
             .run()
             .await
             .map_err(|e| {
-                ArbitrageError::database_error(format!("Failed to execute D1 statement '{}': {}", query, e))
+                ArbitrageError::database_error(format!(
+                    "Failed to execute D1 statement '{}': {}",
+                    query, e
+                ))
             });
 
         if result.is_err() {
@@ -498,11 +512,18 @@ impl DatabaseManager {
             let js_params: Vec<worker::wasm_bindgen::JsValue> =
                 params_list[idx].iter().map(|s| s.into()).collect();
             let bound_stmt = stmt.bind(&js_params).map_err(|e| {
-                ArbitrageError::database_error(format!("Failed to bind parameters for transactional query '{}': {}", query, e))
+                ArbitrageError::database_error(format!(
+                    "Failed to bind parameters for transactional query '{}': {}",
+                    query, e
+                ))
             })?;
             match bound_stmt.run().await {
                 Ok(d1_result) => {
-                    console_log!("D1 transactional query {} executed successfully: {}", idx + 1, query);
+                    console_log!(
+                        "D1 transactional query {} executed successfully: {}",
+                        idx + 1,
+                        query
+                    );
                     let mut parsed_results_for_query = Vec::new();
                     // d1_result.results() returns Result<Vec<serde_json::Value>, Error>, we need to convert to HashMap
                     if let Ok(rows) = d1_result.results::<serde_json::Value>() {

--- a/src/services/core/infrastructure/database_repositories/database_manager.rs
+++ b/src/services/core/infrastructure/database_repositories/database_manager.rs
@@ -430,15 +430,10 @@ impl DatabaseManager {
             })?
             .all()
             .await
-            .map_err(|e| {
-                ArbitrageError::database_error(format!(
-                    "Failed to execute D1 query '{}': {}",
-                    query, e
-                ))
-            });
+            .map_err(|e| ArbitrageError::database_error(format!("Failed to execute D1 query '{}': {}", query, e)));
 
-        if result.is_err() {
-            console_log!("D1 query error: {}", result.as_ref().unwrap_err());
+        if let Err(e) = &result {
+            console_log!("D1 query error: {:?}", e);
         } else {
             console_log!("D1 query executed successfully: {}", query);
         }
@@ -456,26 +451,19 @@ impl DatabaseManager {
         let start_time = current_timestamp_ms();
 
         let stmt = self.db.prepare(query);
-        console_log!("Executing D1 statement: {}", query);
         let result = stmt
             .bind(params)
             .map_err(|e| {
-                ArbitrageError::database_error(format!(
-                    "Failed to bind parameters for statement '{}': {}",
-                    query, e
-                ))
+                ArbitrageError::database_error(format!("Failed to bind parameters for statement '{}': {}", query, e))
             })?
             .run()
             .await
             .map_err(|e| {
-                ArbitrageError::database_error(format!(
-                    "Failed to execute D1 statement '{}': {}",
-                    query, e
-                ))
+                ArbitrageError::database_error(format!("Failed to execute D1 statement '{}': {}", query, e))
             });
 
-        if result.is_err() {
-            console_log!("D1 statement error: {}", result.as_ref().unwrap_err());
+        if let Err(e) = &result {
+            console_log!("D1 statement error: {:?}", e);
         } else {
             console_log!("D1 statement executed successfully: {}", query);
         }

--- a/src/services/core/user/session_management.rs
+++ b/src/services/core/user/session_management.rs
@@ -7,8 +7,8 @@ use crate::utils::{ArbitrageError, ArbitrageResult};
 use serde_json::{self};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use worker::wasm_bindgen::JsValue;
 use worker::console_log;
+use worker::wasm_bindgen::JsValue;
 
 /// Comprehensive session management service for user lifecycle tracking
 /// and push notification eligibility management
@@ -54,15 +54,24 @@ impl SessionManagementService {
         let session = EnhancedUserSession::new(user_id, telegram_id);
 
         // Store in database
-        console_log!("SessionManagementService: Storing session in database for user {}", session.user_id);
+        console_log!(
+            "SessionManagementService: Storing session in database for user {}",
+            session.user_id
+        );
         self.store_session(&session).await?;
 
         // Cache in KV for fast lookups
-        console_log!("SessionManagementService: Caching session in KV for user {}", session.user_id);
+        console_log!(
+            "SessionManagementService: Caching session in KV for user {}",
+            session.user_id
+        );
         self.cache_session(&session).await?;
 
         // Record session analytics
-        console_log!("SessionManagementService: Recording session start for user {}", session.user_id);
+        console_log!(
+            "SessionManagementService: Recording session start for user {}",
+            session.user_id
+        );
         self.record_session_start(&session).await?;
 
         Ok(session)
@@ -73,23 +82,39 @@ impl SessionManagementService {
         &self,
         user_id: &str,
     ) -> ArbitrageResult<Option<EnhancedUserSession>> {
-        console_log!("SessionManagementService: Validating session for user {}", user_id);
+        console_log!(
+            "SessionManagementService: Validating session for user {}",
+            user_id
+        );
         match self.get_session_by_user_id(user_id).await {
             Ok(session) => {
                 if session.is_active() {
-                    console_log!("SessionManagementService: Session active for user {}", user_id);
+                    console_log!(
+                        "SessionManagementService: Session active for user {}",
+                        user_id
+                    );
                     Ok(Some(session))
                 } else {
-                    console_log!("SessionManagementService: Session inactive for user {}", user_id);
+                    console_log!(
+                        "SessionManagementService: Session inactive for user {}",
+                        user_id
+                    );
                     Ok(None)
                 }
             }
             Err(e) if e.error_code.as_deref() == Some("SESSION_NOT_FOUND") => {
-                console_log!("SessionManagementService: Session not found for user {}", user_id);
+                console_log!(
+                    "SessionManagementService: Session not found for user {}",
+                    user_id
+                );
                 Ok(None)
             } // Not found is not an error here
             Err(e) => {
-                console_log!("SessionManagementService: Error getting session for user {}: {:?}", user_id, e);
+                console_log!(
+                    "SessionManagementService: Error getting session for user {}: {:?}",
+                    user_id,
+                    e
+                );
                 Err(e)
             } // Other errors are propagated
         }
@@ -100,23 +125,39 @@ impl SessionManagementService {
         &self,
         telegram_id: i64,
     ) -> ArbitrageResult<Option<EnhancedUserSession>> {
-        console_log!("SessionManagementService: Validating session by Telegram ID {}", telegram_id);
+        console_log!(
+            "SessionManagementService: Validating session by Telegram ID {}",
+            telegram_id
+        );
         match self.get_session_by_telegram_id(telegram_id).await {
             Ok(session) => {
                 if session.is_active() {
-                    console_log!("SessionManagementService: Session active for Telegram ID {}", telegram_id);
+                    console_log!(
+                        "SessionManagementService: Session active for Telegram ID {}",
+                        telegram_id
+                    );
                     Ok(Some(session))
                 } else {
-                    console_log!("SessionManagementService: Session inactive for Telegram ID {}", telegram_id);
+                    console_log!(
+                        "SessionManagementService: Session inactive for Telegram ID {}",
+                        telegram_id
+                    );
                     Ok(None)
                 }
             }
             Err(e) if e.error_code.as_deref() == Some("SESSION_NOT_FOUND") => {
-                console_log!("SessionManagementService: Session not found for Telegram ID {}", telegram_id);
+                console_log!(
+                    "SessionManagementService: Session not found for Telegram ID {}",
+                    telegram_id
+                );
                 Ok(None)
             } // Not found is not an error here
             Err(e) => {
-                console_log!("SessionManagementService: Error getting session for Telegram ID {}: {:?}", telegram_id, e);
+                console_log!(
+                    "SessionManagementService: Error getting session for Telegram ID {}: {:?}",
+                    telegram_id,
+                    e
+                );
                 Err(e)
             } // Other errors are propagated
         }
@@ -124,13 +165,22 @@ impl SessionManagementService {
 
     /// Update user activity and extend session
     pub async fn update_activity(&self, user_id: &str) -> ArbitrageResult<()> {
-        console_log!("SessionManagementService: Updating activity for user {}", user_id);
+        console_log!(
+            "SessionManagementService: Updating activity for user {}",
+            user_id
+        );
         let mut session = self.get_session_by_user_id(user_id).await?;
         session.update_activity();
 
-        console_log!("SessionManagementService: Updating session in DB for user {}", user_id);
+        console_log!(
+            "SessionManagementService: Updating session in DB for user {}",
+            user_id
+        );
         self.update_session(&session).await?;
-        console_log!("SessionManagementService: Caching updated session in KV for user {}", user_id);
+        console_log!(
+            "SessionManagementService: Caching updated session in KV for user {}",
+            user_id
+        );
         self.cache_session(&session).await?;
 
         Ok(())
@@ -138,13 +188,22 @@ impl SessionManagementService {
 
     /// Update activity by telegram ID (faster)
     pub async fn update_activity_by_telegram_id(&self, telegram_id: i64) -> ArbitrageResult<()> {
-        console_log!("SessionManagementService: Updating activity for Telegram ID {}", telegram_id);
+        console_log!(
+            "SessionManagementService: Updating activity for Telegram ID {}",
+            telegram_id
+        );
         let mut session = self.get_session_by_telegram_id(telegram_id).await?;
         session.update_activity();
 
-        console_log!("SessionManagementService: Updating session in DB for Telegram ID {}", telegram_id);
+        console_log!(
+            "SessionManagementService: Updating session in DB for Telegram ID {}",
+            telegram_id
+        );
         self.update_session(&session).await?;
-        console_log!("SessionManagementService: Caching updated session in KV for Telegram ID {}", telegram_id);
+        console_log!(
+            "SessionManagementService: Caching updated session in KV for Telegram ID {}",
+            telegram_id
+        );
         self.cache_session(&session).await?;
 
         Ok(())
@@ -152,17 +211,29 @@ impl SessionManagementService {
 
     /// End a session manually
     pub async fn end_session(&self, user_id: &str) -> ArbitrageResult<()> {
-        console_log!("SessionManagementService: Ending session for user {}", user_id);
+        console_log!(
+            "SessionManagementService: Ending session for user {}",
+            user_id
+        );
         let mut session = self.get_session_by_user_id(user_id).await?;
         session.terminate();
 
-        console_log!("SessionManagementService: Updating session in DB (terminated) for user {}", user_id);
+        console_log!(
+            "SessionManagementService: Updating session in DB (terminated) for user {}",
+            user_id
+        );
         self.update_session(&session).await?;
-        console_log!("SessionManagementService: Invalidating session cache for user {}", user_id);
+        console_log!(
+            "SessionManagementService: Invalidating session cache for user {}",
+            user_id
+        );
         self.invalidate_session_cache(session.telegram_id).await?;
 
         // Record session analytics
-        console_log!("SessionManagementService: Recording session end for user {}", user_id);
+        console_log!(
+            "SessionManagementService: Recording session end for user {}",
+            user_id
+        );
         self.record_session_end(&session, SessionOutcome::Terminated)
             .await?;
 
@@ -171,7 +242,10 @@ impl SessionManagementService {
 
     /// Get session by session ID
     pub async fn get_session(&self, session_id: &str) -> ArbitrageResult<EnhancedUserSession> {
-        console_log!("SessionManagementService: Getting session by ID {}", session_id);
+        console_log!(
+            "SessionManagementService: Getting session by ID {}",
+            session_id
+        );
         let stmt = self.d1_service.prepare(
             "SELECT * FROM user_sessions WHERE session_id = ? AND session_state = 'active' ORDER BY created_at DESC LIMIT 1"
         );
@@ -189,23 +263,35 @@ impl SessionManagementService {
 
         match result {
             Some(row) => {
-                console_log!("SessionManagementService: Session found by ID {}", session_id);
+                console_log!(
+                    "SessionManagementService: Session found by ID {}",
+                    session_id
+                );
                 // Convert serde_json::Value to HashMap
                 let row_map = if let serde_json::Value::Object(map) = row {
                     map.into_iter()
                         .collect::<std::collections::HashMap<String, serde_json::Value>>()
                 } else {
-                    console_log!("SessionManagementService: Invalid row format for session ID {}", session_id);
+                    console_log!(
+                        "SessionManagementService: Invalid row format for session ID {}",
+                        session_id
+                    );
                     return Err(ArbitrageError::database_error("Invalid row format"));
                 };
                 let session = self.row_to_session(row_map)?;
                 // Cache for future lookups
-                console_log!("SessionManagementService: Caching session from DB for ID {}", session_id);
+                console_log!(
+                    "SessionManagementService: Caching session from DB for ID {}",
+                    session_id
+                );
                 self.cache_session(&session).await?;
                 Ok(session)
             }
             None => {
-                console_log!("SessionManagementService: Session not found for ID {}", session_id);
+                console_log!(
+                    "SessionManagementService: Session not found for ID {}",
+                    session_id
+                );
                 Err(ArbitrageError::session_not_found(session_id.to_string()))
             }
         }
@@ -216,7 +302,10 @@ impl SessionManagementService {
         &self,
         user_id: &str,
     ) -> ArbitrageResult<EnhancedUserSession> {
-        console_log!("SessionManagementService: Getting session by user ID {}", user_id);
+        console_log!(
+            "SessionManagementService: Getting session by user ID {}",
+            user_id
+        );
         let stmt = self.d1_service.prepare(
             "SELECT * FROM user_sessions WHERE user_id = ? AND session_state = 'active' ORDER BY created_at DESC LIMIT 1"
         );
@@ -234,13 +323,19 @@ impl SessionManagementService {
 
         match result {
             Some(row) => {
-                console_log!("SessionManagementService: Session found by user ID {}", user_id);
+                console_log!(
+                    "SessionManagementService: Session found by user ID {}",
+                    user_id
+                );
                 self.row_to_session(row)
-            },
+            }
             None => {
-                console_log!("SessionManagementService: Session not found for user ID {}", user_id);
+                console_log!(
+                    "SessionManagementService: Session not found for user ID {}",
+                    user_id
+                );
                 Err(ArbitrageError::session_not_found(user_id))
-            },
+            }
         }
     }
 
@@ -249,13 +344,19 @@ impl SessionManagementService {
         &self,
         telegram_id: i64,
     ) -> ArbitrageResult<EnhancedUserSession> {
-        console_log!("SessionManagementService: Getting session by Telegram ID {} (checking KV cache first)", telegram_id);
+        console_log!(
+            "SessionManagementService: Getting session by Telegram ID {} (checking KV cache first)",
+            telegram_id
+        );
         // Try KV cache first
         let cache_key = format!("session_cache:{}", telegram_id);
         if let Ok(Some(cached_data)) = self.kv_service.get(&cache_key).text().await {
             if let Ok(session) = serde_json::from_str::<EnhancedUserSession>(&cached_data) {
                 if session.is_active() {
-                    console_log!("SessionManagementService: Session found in KV cache for Telegram ID {}", telegram_id);
+                    console_log!(
+                        "SessionManagementService: Session found in KV cache for Telegram ID {}",
+                        telegram_id
+                    );
                     return Ok(session);
                 }
             }
@@ -283,17 +384,26 @@ impl SessionManagementService {
 
         match result {
             Some(row) => {
-                console_log!("SessionManagementService: Session found in DB for Telegram ID {}", telegram_id);
+                console_log!(
+                    "SessionManagementService: Session found in DB for Telegram ID {}",
+                    telegram_id
+                );
                 let session = self.row_to_session(row)?;
                 // Cache for future lookups
-                console_log!("SessionManagementService: Caching session from DB for Telegram ID {}", telegram_id);
+                console_log!(
+                    "SessionManagementService: Caching session from DB for Telegram ID {}",
+                    telegram_id
+                );
                 self.cache_session(&session).await?;
                 Ok(session)
             }
             None => {
-                console_log!("SessionManagementService: Session not found in DB for Telegram ID {}", telegram_id);
+                console_log!(
+                    "SessionManagementService: Session not found in DB for Telegram ID {}",
+                    telegram_id
+                );
                 Err(ArbitrageError::session_not_found(telegram_id.to_string()))
-            },
+            }
         }
     }
 
@@ -624,7 +734,10 @@ impl SessionManagementService {
 
     /// Store session in database
     async fn store_session(&self, session: &EnhancedUserSession) -> ArbitrageResult<()> {
-        console_log!("SessionManagementService (store_session): Storing session {}", session.session_id);
+        console_log!(
+            "SessionManagementService (store_session): Storing session {}",
+            session.session_id
+        );
         // Validate telegram_id before storing
         Self::validate_telegram_id_for_js(session.telegram_id)?;
         let stmt = self.d1_service.prepare(
@@ -664,7 +777,10 @@ impl SessionManagementService {
 
     /// Update existing session in database
     async fn update_session(&self, session: &EnhancedUserSession) -> ArbitrageResult<()> {
-        console_log!("SessionManagementService (update_session): Updating session {}", session.session_id);
+        console_log!(
+            "SessionManagementService (update_session): Updating session {}",
+            session.session_id
+        );
         let stmt = self.d1_service.prepare(
             r#"
             UPDATE user_sessions SET
@@ -696,7 +812,10 @@ impl SessionManagementService {
 
     /// Cache session in KV store for fast lookups
     async fn cache_session(&self, session: &EnhancedUserSession) -> ArbitrageResult<()> {
-        console_log!("SessionManagementService (cache_session): Caching session {}", session.session_id);
+        console_log!(
+            "SessionManagementService (cache_session): Caching session {}",
+            session.session_id
+        );
         let cache_key = format!("session_cache:{}", session.telegram_id);
         let session_json = serde_json::to_string(session).map_err(|e| {
             ArbitrageError::parse_error(format!("Failed to serialize session: {}", e))


### PR DESCRIPTION
To diagnose a Cloudflare Workers runtime hang, extensive logging was introduced.

*   In `src/services/core/infrastructure/database_repositories/database_manager.rs`:
    *   `console_log!` statements were added around D1 database `query`, `execute`, and `execute_transactional` methods.
    *   Logs now indicate the query/statement being executed, parameter binding status, and success/failure of the D1 operation, including error messages.
    *   This aims to pinpoint which specific D1 call is causing the hang.

*   In `src/services/core/user/session_management.rs`:
    *   `console_log!` statements were added to all public and private asynchronous methods that interact with D1 or KV, such as `create_session`, `validate_session`, `update_activity`, `get_session_by_telegram_id`, `store_session`, and `cache_session`.
    *   These logs trace the flow through session management, indicating when D1 or KV operations are initiated and their outcomes.
    *   The intention is to identify the exact asynchronous operation (D1 or KV) that is not resolving, leading to the worker hanging.

These changes provide detailed visibility into database and KV interactions, which are suspected causes of the worker's unresponsiveness.